### PR TITLE
CF-2601 This reverts CF-1931, which was backed out

### DIFF
--- a/lib/neverblock/io/io.rb
+++ b/lib/neverblock/io/io.rb
@@ -7,24 +7,17 @@ require 'openssl'
 # Copyright:: Copyright (c) 2009 eSpace, Inc.
 # License::   Distributes under the same terms as Ruby
 
-# DJR 2016-06-15 -> Neverblock can stop openssl from establishing a connection because of a timeout.
-# Turning off neverblock for SSL connect
-
 class OpenSSL::SSL::SSLSocket
-  alias_method :connect_blocking, :connect
   def connect
-    # old nonblocking but ssl error causing method
-    # begin
-    #   connect_nonblock
-    # rescue IO::WaitReadable
-    #   NB.wait(:read, self)
-    #   retry
-    # rescue IO::WaitWritable
-    #   NB.wait(:write, self)
-    #   retry
-    # end
-    
-    connect_blocking
+    begin
+      connect_nonblock
+    rescue IO::WaitReadable
+      NB.wait(:read, self)
+      retry
+    rescue IO::WaitWritable
+      NB.wait(:write, self)
+      retry
+    end
   end
 end
 

--- a/lib/neverblock/io/socket.rb
+++ b/lib/neverblock/io/socket.rb
@@ -40,12 +40,10 @@ class BasicSocket < IO
 
 end
 
-
-# Commenting out connect neverblocking.  This can cause SSL errors
 class Socket < BasicSocket
   
   alias_method :connect_blocking, :connect
-  
+      
   def connect_neverblock(server_sockaddr)
     begin
       connect_nonblock(server_sockaddr)
@@ -58,11 +56,11 @@ class Socket < BasicSocket
   end
     
   def connect(server_sockaddr)
-#     if NB.neverblocking?
-#       connect_neverblock(server_sockaddr)
-#     else
-    connect_blocking(server_sockaddr)
-#     end
+    if NB.neverblocking?
+      connect_neverblock(server_sockaddr)
+    else
+      connect_blocking(server_sockaddr)
+    end
   end
 
 end


### PR DESCRIPTION
Neverblock centered fix was backed out in favor of a cloud_gateway
related fix. v2.1 is currently used in production and this brings master
in line with v2.1.